### PR TITLE
Make locations of webform link and inline ajax webform alterable #37

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -47,7 +47,7 @@ Configuration is found at Islandora > Configuration > Islandora Webform (/admin/
    controls whether clicking on a webform link opens a new page/tab or replaces
    the current window.
 2. "Append webform links to bottom of object view?": Uncheck this if you want to
-   override the normal positioning of the webform links (below the object display).
+   override the normal positioning of the webform links below the object display.
 
 
 Permissions

--- a/README.txt
+++ b/README.txt
@@ -39,6 +39,17 @@ Installation
    to a webform, and click the link to add it.
 
 
+Configuration
+-------------
+Configuration is found at Islandora > Configuration > Islandora Webform (/admin/islandora/configure/iw).
+
+1. "Webform link behavior": If not using inline webforms with webform_ajax, this
+   controls whether clicking on a webform link opens a new page/tab or replaces
+   the current window.
+2. "Append webform links to bottom of object view?": Uncheck this if you want to
+   override the normal positioning of the webform links (below the object display).
+
+
 Permissions
 -----------------------------
 This module defines the following permissions:

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -33,6 +33,13 @@ function islandora_webform_admin(array $form, array &$form_state) {
             'same' => "Same window",
           ),
         ),
+        'islandora_webform_link_object_view_alter' => array(
+          '#type' => 'checkbox',
+          '#title' => t('Append webform links to bottom of object view?'),
+          '#default_value' => variable_get('islandora_webform_link_object_view_alter', 1),
+          '#description' => t('Unchecking this option will require that you customize the theming of  object pages in order for the webform links to appear. See islandora_webform_theme() and theme_islandora_webform_links()'),
+          '#return_value' => 1,
+          ),
       ),
     ),
   );

--- a/includes/inline_webform.inc
+++ b/includes/inline_webform.inc
@@ -22,14 +22,16 @@ function _iw_inline_webform($webform, $ajax) {
   $form = drupal_get_form('webform_client_form_' . $webform->nid, $webform, $submission, $enabled);
   if ($ajax == 'ajax') {
     // We remove the container of the form.
-    $commands[] = ajax_command_remove('.webform-links-wrapper.opened > div:not(.webform-links)');
+    $commands['remove-container'] = ajax_command_remove('.webform-links-wrapper.opened > div:not(.webform-links)');
     // Set css on webform links wrapper.
-    $commands[] = ajax_command_invoke('.webform-links-wrapper', 'removeClass', array('opened'));
-    $commands[] = ajax_command_invoke('#iw_iwebform_links_' . $webform->nid . '.webform-links-wrapper', 'addClass', array('opened'));
+    $commands['remove-wrapper-class'] = ajax_command_invoke('.webform-links-wrapper', 'removeClass', array('opened'));
+    $commands['add-wrapper-class'] = ajax_command_invoke('#iw_iwebform_links_' . $webform->nid . '.webform-links-wrapper', 'addClass', array('opened'));
     // Get the html of the new form.
     $html = render($form);
     $jquery_selector = '#iw_iwebform_links_' . $webform->nid . ' .webform-links';
-    $commands[] = ajax_command_after($jquery_selector, $html);
+    $commands['jquery-selector'] = ajax_command_after($jquery_selector, $html);
+    $vars = array('webform' => $webform, 'form' => $form, 'html' => $html);
+    drupal_alter('iw_inline_webform_ajax_commands', $commands, $vars);
     return array(
       '#type' => 'ajax',
       '#commands' => $commands,

--- a/islandora_webform.api.php
+++ b/islandora_webform.api.php
@@ -22,6 +22,39 @@ function hook_iw_results_object_submissions_page_element_alter(&$element) {
 }
 
 /**
+ * Modify islandora inline webform ajax commands.
+ *
+ * This hook permits modules to modify the ajax commands that set behavior
+ * when an inline webform link is clicked when webform_ajax is enabled.
+ * The $commands array variable is passed by reference and may be modified by
+ * this hook.
+ *
+ * @param &$commands
+ *   An array of ajax commands. Provided commands have the following keys:
+ *     'remove-container',
+ *     'remove-wrapper-class'
+ *     'add-wrapper-class'
+ *     'jquery-selector'
+ *   Look at the _iw_inline_webform() function for details.
+ *
+ * @param array $vars
+ *   An array of useful data, indexed as follows:
+ *   'webform' object
+ *     The webform node
+ *   'form' array
+ *     The render array for the webform
+ *   'html' string
+ *     The rendered html of that webform
+ *
+ */
+function hook_iw_inline_webform_ajax_commands_alter(&$commands, $vars) {
+
+  // We're going to have the webform appear in a different place on the page.
+  $jquery_selector = '#my_inline_webform_ajax_target_' . $vars['webform']->nid;
+  $commands['jquery-selector'] = ajax_command_after($jquery_selector, $vars['html']);
+}
+
+/**
  * Modify islandora webform link markup.
  *
  * @param $webform_link

--- a/islandora_webform.api.php
+++ b/islandora_webform.api.php
@@ -20,3 +20,18 @@
 function hook_iw_results_object_submissions_page_element_alter(&$element) {
   $element['table']['#prefix'] = '<h2>Blah blah</h2>';
 }
+
+/**
+ * Modify islandora webform link markup.
+ *
+ * @param $webform_link
+ *   Html for the webform link.
+ *
+ * @param $islandora_webform_record
+ */
+function hook_islandora_webform_theme_webform_link_alter(&$webform_link, $islandora_webform_record) {
+  // Example: Display the help text above the link.
+  if(!empty($islandora_webform_record->link_help)) {
+    $webform_link = '<div class="webform-link-label">'. $islandora_webform_record->link_help . '</div><div class="webform-link">' . $webform_link . '</div>';
+  }
+}

--- a/islandora_webform.module
+++ b/islandora_webform.module
@@ -256,19 +256,20 @@ function islandora_webform_node_access($node, $op, $account) {
  */
 function islandora_webform_islandora_view_object_alter(&$object, &$rendered) {
 
-  module_load_include('inc', 'islandora_webform', 'includes/utilities');
-  $webforms = islandora_webform_object_get_webforms($object);
+  if (variable_get('islandora_webform_link_object_view_alter', 1)) {
+    module_load_include('inc', 'islandora_webform', 'includes/utilities');
+    $webforms = islandora_webform_object_get_webforms($object);
 
-  if (!empty($webforms)) {
-    $rendered += array(
-      'webform_links' => theme('islandora_webform_links', array(
-        'webform_data' => $webforms,
-        'islandora_object' => $object,
-        )
-      ),
-    );
+    if (!empty($webforms)) {
+      $rendered += array(
+        'webform_links' => theme('islandora_webform_links', array(
+            'webform_data' => $webforms,
+            'islandora_object' => $object,
+          )
+        ),
+      );
+    }
   }
-
 }
 
 /**

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -150,6 +150,7 @@ function islandora_webform_theme_webform_link($islandora_webform_record, $webfor
     $link_path = $link_mode == 'inline' ? 'islandora_webform/retrieve_form/' . $islandora_webform_record->entity_id . '/nojs' : drupal_get_path_alias('node/' . $islandora_webform_record->entity_id);
     $webform_link_options['attributes']['title'] = $islandora_webform_record->link_help;
     $webform_link = l($islandora_webform_record->link_text, $link_path, $webform_link_options);
+    drupal_alter('islandora_webform_theme_webform_link', $webform_link, $islandora_webform_record);
   }
   return $webform_link;
 }


### PR DESCRIPTION
**Ticket**: https://github.com/commonmedia/islandora_webform/issues/37

# What does this Pull Request do?

Enables more flexibility in location and behavior of webform links on the object page.

# What's new?

- Adds a checkbox to the module configuration page (/admin/islandora/configure/iw): "Append webform links to bottom of object view?" Default is yes, and causes the webform links to be displayed below the object, as before. When unchecked, they will not be displayed, and it is up to the site themer to place them on the page.
 - Adds a hook to alter the ajax commands that are run when the inline webform loads. This can make the webform load into a div elsewhere on the page.
 - Adds a hook to alter the markup for each webform link.
 - Adds a bit of configuration instructions to README.md

# How should this be tested?

* Install islandora_webform, webform and webform_ajax; create a webform configured to display a link to an inline webform  for an islandora object. _Does the link appear and load the webform as before?_
* Go to /admin/islandora/configure/iw and uncheck the checkbox "Append webform links to bottom of object view?". _Do webform links no longer appear?_
* Modify any template involved in displaying the object page to add an empty target div for the webform that can be uniquely identified by id or class; Implement hook_iw_inline_webform_ajax_commands_alter along the lines of the example provided in islandora_webform.api.php to change the jquery-selector target this div. Re-enable "Append webform links to bottom of object view?" on the islandora webform configuration page. _Does clicking on the webform link cause the webform to be loaded into this alternate location on the page?_
* Implement e.g. a preprocess function to load the themed weblinks into $variables; then modify the corresponding template file to display them; Disable "Append webform links to bottom of object view?" so that the webform links do not appear in the default location below the object. _Do the webform links appear in the new location and behave as expected?_

# Additional Notes:

* Does this change require documentation to be updated? _Yes, and is included in the PR_
* Does this change add any new dependencies? _No_
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? _No_
* Could this change impact execution of existing code? _No_

# Interested parties
@petermacdonald @McFateM