### PR TITLE
PHP less than 7 patch - no null coalescing op

### DIFF
--- a/submodules/islandora_webform_embargo/islandora_webform_embargo.module
+++ b/submodules/islandora_webform_embargo/islandora_webform_embargo.module
@@ -22,7 +22,7 @@ function _get_islandora_webform_embargo_settings($nid, $sid = FALSE) {
     $single_record = $defaults->execute()->fetchObject();
   }
 
-  return $single_record ?? FALSE;
+  return isset($single_record) ? $single_record) : FALSE;
 }
 
 /**

--- a/submodules/islandora_webform_embargo/islandora_webform_embargo.module
+++ b/submodules/islandora_webform_embargo/islandora_webform_embargo.module
@@ -22,7 +22,7 @@ function _get_islandora_webform_embargo_settings($nid, $sid = FALSE) {
     $single_record = $defaults->execute()->fetchObject();
   }
 
-  return isset($single_record) ? $single_record) : FALSE;
+  return isset($single_record) ? $single_record : FALSE;
 }
 
 /**

--- a/submodules/islandora_webform_embargo/islandora_webform_embargo.module
+++ b/submodules/islandora_webform_embargo/islandora_webform_embargo.module
@@ -22,7 +22,7 @@ function _get_islandora_webform_embargo_settings($nid, $sid = FALSE) {
     $single_record = $defaults->execute()->fetchObject();
   }
 
-  return isset($single_record) ? $single_record : FALSE;
+  isset($single_record) ? return $single_record : return FALSE;
 }
 
 /**


### PR DESCRIPTION
See https://www.php.net/manual/en/migration70.new-features.php

Islandora is tested against PHP <7, so we can't use features only available for 7.

cc @bondjimbond  ref #54 